### PR TITLE
attempt to parse invalid protos as strings

### DIFF
--- a/lib/src/driver/driver_connection.dart
+++ b/lib/src/driver/driver_connection.dart
@@ -37,6 +37,12 @@ class StdDriverConnection implements DriverConnection {
       new StdDriverConnection(
           inputStream: worker.stdout, outputStream: worker.stdin);
 
+  /// Note: This will attempts to recover from invalid proto messages by parsing
+  /// them as strings. This is a common error case for workers (they print a
+  /// message to stdout on accident). This isn't perfect however as it only
+  /// happens if the parsing throws, you can still hang indefinitely if the
+  /// [MessageGrouper] doesn't find what it thinks is the end of a proto
+  /// message.
   @override
   Future<WorkResponse> readResponse() async {
     var buffer = await _messageGrouper.next;


### PR DESCRIPTION
Note that this doesn't really handle all cases, because sometimes the message grouper will simply fail to find what it thinks is the end of a proto message so it may hang indefinitely.

In the case where the encoded output string fools the message grouper into thinking it is a proto message it does help (and in fact enough so that it helped me debug an issue when integrating this with pub).