### PR TITLE
Fix fuzzy arrow warning in lib/testing.dart.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.0
+
+* Change TestStdinAsync.controller to StreamController<List<int>> (instead of
+  using dynamic as the type argument).
+
 ## 0.1.4
 
 * Added `BazelWorkerDriver` class, which can be used to implement the bazel side

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.0
+## 0.1.5
 
 * Change TestStdinAsync.controller to StreamController<List<int>> (instead of
   using dynamic as the type argument).

--- a/lib/testing.dart
+++ b/lib/testing.dart
@@ -50,8 +50,8 @@ class TestStdinSync implements TestStdin {
 /// Note: You must call [close] in order for the loop to exit properly.
 class TestStdinAsync implements TestStdin {
   /// Controls the stream for async delivery of bytes.
-  final StreamController _controller = new StreamController();
-  StreamController get controller => _controller;
+  final StreamController<List<int>> _controller = new StreamController();
+  StreamController<List<int>> get controller => _controller;
 
   /// Adds all the [bytes] to this stream.
   void addInputBytes(List<int> bytes) {
@@ -67,9 +67,7 @@ class TestStdinAsync implements TestStdin {
   StreamSubscription<List<int>> listen(onData(List<int> bytes),
       {Function onError, void onDone(), bool cancelOnError}) {
     return _controller.stream.listen(onData,
-        onError: onError,
-        onDone: onDone,
-        cancelOnError: cancelOnError) as StreamSubscription<List<int>>;
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bazel_worker
-version: 0.1.4
+version: 0.2.0-dev
 description: Tools for creating a bazel persistent worker.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/bazel_worker

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bazel_worker
-version: 0.2.0-dev
+version: 0.1.5
 description: Tools for creating a bazel persistent worker.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/bazel_worker

--- a/test/worker_loop_test.dart
+++ b/test/worker_loop_test.dart
@@ -48,13 +48,13 @@ void main() {
   });
 }
 
-void runTests/*<T extends TestWorkerConnection>*/(
+void runTests<T extends TestWorkerConnection>(
     TestStdin stdinFactory(),
-    /*=T*/ workerConnectionFactory(Stdin stdin, Stdout stdout),
-    TestWorkerLoop workerLoopFactory(/*=T*/ connection)) {
+    T workerConnectionFactory(Stdin stdin, Stdout stdout),
+    TestWorkerLoop workerLoopFactory(T connection)) {
   TestStdin stdinStream;
   TestStdoutStream stdoutStream;
-  var/*=T*/ connection;
+  T connection;
   TestWorkerLoop workerLoop;
 
   setUp(() {


### PR DESCRIPTION
Context: https://github.com/dart-lang/sdk/issues/29630

I also fixed a few places to use the real generic method syntax while
I was at it.

I bumped the version to 0.2.0-dev since my change is technically
breaking -- it changes the return type of TestStdinAsync.controller.
If you don't feel that will actually break any real users, I can do
0.1.5-dev instead.

This needs to roll into Google after I land it. If you'd like me to
publish this, let me know and I'll do 0.1.5 instead.