### PR TITLE
Add cancel method to `BazelWorkerConnection` and use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.8
+
+* Add `Future cancel()` method to `DriverConnection`, which in the case of a
+  `StdDriverConnection` closes the input stream.
+  * The `terminateWorkers` method on `BazelWorkerDriver` now calls `cancel` on
+    all worker connections to ensure the vm can exit correctly.
+
 ## 0.1.7
 
 * Update the `BazelWorkerDriver` class to handle worker crashes, and retry work

--- a/lib/src/async_message_grouper.dart
+++ b/lib/src/async_message_grouper.dart
@@ -19,6 +19,9 @@ class AsyncMessageGrouper implements MessageGrouper {
   /// The input stream.
   final StreamQueue<List<int>> _inputQueue;
 
+  // Whether or not the input queue has already been cancelled.
+  bool _inputQueueCancelled = false;
+
   /// The current buffer.
   final Queue<int> _buffer = new Queue<int>();
 
@@ -38,7 +41,7 @@ class AsyncMessageGrouper implements MessageGrouper {
       }
 
       // If there is nothing left in the queue then cancel the subscription.
-      if (message == null) _inputQueue.cancel();
+      if (message == null) _cancel();
 
       return message;
     } catch (e) {
@@ -49,6 +52,14 @@ class AsyncMessageGrouper implements MessageGrouper {
     }
   }
 
+  Future _cancel() {
+    if (!_inputQueueCancelled) {
+      _inputQueueCancelled = true;
+      return _inputQueue.cancel();
+    }
+    return new Future.value(null);
+  }
+
   /// Stop listening to the stream for further updates.
-  Future cancel() => _inputQueue.cancel();
+  Future cancel() => _cancel();
 }

--- a/lib/src/driver/driver_connection.dart
+++ b/lib/src/driver/driver_connection.dart
@@ -20,6 +20,8 @@ abstract class DriverConnection {
   Future<WorkResponse> readResponse();
 
   void writeRequest(WorkRequest request);
+
+  Future cancel();
 }
 
 /// Default implementation of [DriverConnection] that works with [Stdin]
@@ -72,4 +74,7 @@ class StdDriverConnection implements DriverConnection {
   void writeRequest(WorkRequest request) {
     _outputStream.add(protoToDelimitedBuffer(request));
   }
+
+  @override
+  Future cancel() => _messageGrouper.cancel();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bazel_worker
-version: 0.1.7
+version: 0.1.8
 description: Tools for creating a bazel persistent worker.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/bazel_worker


### PR DESCRIPTION
Calling `terminateWorkers` on a `BazelWorkerDriver` will now also close their connections if they aren't already closed.

Fixes https://github.com/dart-lang/build/issues/655