### PR TITLE
Update e2e example environment constraint

### DIFF
--- a/e2e_test/pubspec.yaml
+++ b/e2e_test/pubspec.yaml
@@ -6,3 +6,5 @@ dev_dependencies:
   cli_util: ^0.1.0
   path: ^1.4.1
   test: ^0.12.0
+environment:
+  sdk: '>=2.0.0-dev.17.0 <3.0.0'

--- a/e2e_test/pubspec.yaml
+++ b/e2e_test/pubspec.yaml
@@ -5,6 +5,6 @@ dependencies:
 dev_dependencies:
   cli_util: ^0.1.0
   path: ^1.4.1
-  test: ^0.12.0
+  test: ^1.0.0
 environment:
-  sdk: '>=2.0.0-dev.17.0 <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'


### PR DESCRIPTION
Travis started failing because of the first dev release and the implicit upper bound of <2.0.0 now.