### PR TITLE
add trackWork argument to BazelWorkerDriver.doWork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.18
+
+* Add a `trackWork` optional named argument to `BazelDriver.doWork`. This allows
+  the caller to know when a work request is actually sent to a worker.
+
 ## 0.1.17
 
 * Allow protobuf 0.13.0.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bazel_worker
-version: 0.1.17
+version: 0.1.18
 
 description: Tools for creating a bazel persistent worker.
 author: Dart Team <misc@dartlang.org>


### PR DESCRIPTION
This allows us to more accurately track work for workers in the performance timeline - we can separate out the time spent waiting for a worker to be available versus the actual time to complete the work request.