### PR TITLE
Fix newly enforced package:pedantic lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,7 @@
 include: package:pedantic/analysis_options.yaml
 
 analyzer:
+  exclude: ['lib/src/worker_protocol.pb.dart']
 
 linter:
   rules:
@@ -21,7 +22,6 @@ linter:
     - package_prefixed_library_names
     - prefer_is_not_empty
     - slash_for_doc_comments
-    - sort_unnamed_constructors_first
     # - type_annotate_public_apis
     - type_init_formals
     - unnecessary_brace_in_string_interps

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,6 @@
 include: package:pedantic/analysis_options.yaml
 
 analyzer:
-  exclude: ['lib/src/worker_protocol.pb.dart']
 
 linter:
   rules:

--- a/e2e_test/lib/async_worker.dart
+++ b/e2e_test/lib/async_worker.dart
@@ -14,6 +14,7 @@ class ExampleAsyncWorker extends AsyncWorkerLoop {
   ExampleAsyncWorker([SendPort sendPort])
       : super(connection: AsyncWorkerConnection(sendPort: sendPort));
 
+  @override
   Future<WorkResponse> performRequest(WorkRequest request) async {
     return WorkResponse()
       ..exitCode = 0

--- a/e2e_test/lib/forwards_to_isolate_async_worker.dart
+++ b/e2e_test/lib/forwards_to_isolate_async_worker.dart
@@ -20,6 +20,7 @@ class ForwardsToIsolateAsyncWorker extends AsyncWorkerLoop {
 
   ForwardsToIsolateAsyncWorker(this._isolateDriverConnection);
 
+  @override
   Future<WorkResponse> performRequest(WorkRequest request) {
     _isolateDriverConnection.writeRequest(request);
     return _isolateDriverConnection.readResponse();

--- a/e2e_test/lib/sync_worker.dart
+++ b/e2e_test/lib/sync_worker.dart
@@ -7,6 +7,7 @@ import 'package:bazel_worker/bazel_worker.dart';
 /// Example worker that just returns in its response all the arguments passed
 /// separated by newlines.
 class ExampleSyncWorker extends SyncWorkerLoop {
+  @override
   WorkResponse performRequest(WorkRequest request) {
     return WorkResponse()
       ..exitCode = 0

--- a/e2e_test/test/e2e_test.dart
+++ b/e2e_test/test/e2e_test.dart
@@ -54,7 +54,7 @@ Future _doRequests(BazelWorkerDriver driver, {int count}) async {
     return request;
   });
   var responses = await Future.wait(requests.map(driver.doWork));
-  for (int i = 0; i < responses.length; i++) {
+  for (var i = 0; i < responses.length; i++) {
     var request = requests[i];
     var response = responses[i];
     expect(response.exitCode, EXIT_CODE_OK);

--- a/lib/src/async_message_grouper.dart
+++ b/lib/src/async_message_grouper.dart
@@ -30,6 +30,7 @@ class AsyncMessageGrouper implements MessageGrouper {
       : _inputQueue = StreamQueue(inputStream);
 
   /// Returns the next full message that is received, or null if none are left.
+  @override
   Future<List<int>> get next async {
     try {
       List<int> message;

--- a/lib/src/driver/driver.dart
+++ b/lib/src/driver/driver.dart
@@ -46,9 +46,9 @@ class BazelWorkerDriver {
 
   BazelWorkerDriver(this._spawnWorker,
       {int maxIdleWorkers, int maxWorkers, int maxRetries})
-      : this._maxIdleWorkers = maxIdleWorkers ?? 4,
-        this._maxWorkers = maxWorkers ?? 4,
-        this._maxRetries = maxRetries ?? 4;
+      : _maxIdleWorkers = maxIdleWorkers ?? 4,
+        _maxWorkers = maxWorkers ?? 4,
+        _maxRetries = maxRetries ?? 4;
 
   /// Waits for an available worker, and then sends [WorkRequest] to it.
   ///
@@ -129,7 +129,7 @@ class BazelWorkerDriver {
   /// Once the worker responds then it will be added back to the pool of idle
   /// workers.
   void _runWorker(Process worker, _WorkAttempt attempt) {
-    bool rescheduled = false;
+    var rescheduled = false;
 
     runZoned(() async {
       var connection = _workerConnections[worker];

--- a/lib/src/message_grouper_state.dart
+++ b/lib/src/message_grouper_state.dart
@@ -105,7 +105,7 @@ class _MessageReader {
     return _message;
   }
 
-  Uint8List _message;
+  final Uint8List _message;
 
   /// If [_done] is `false`, the number of message bytes that have been received
   /// so far.  Otherwise zero.

--- a/lib/src/sync_message_grouper.dart
+++ b/lib/src/sync_message_grouper.dart
@@ -17,6 +17,7 @@ class SyncMessageGrouper implements MessageGrouper {
   /// Blocks until the next full message is received, and then returns it.
   ///
   /// Returns null at end of file.
+  @override
   List<int> get next {
     try {
       List<int> message;

--- a/lib/src/worker/async_worker_loop.dart
+++ b/lib/src/worker/async_worker_loop.dart
@@ -16,13 +16,15 @@ abstract class AsyncWorkerLoop implements WorkerLoop {
   final AsyncWorkerConnection connection;
 
   AsyncWorkerLoop({AsyncWorkerConnection connection})
-      : this.connection = connection ?? StdAsyncWorkerConnection();
+      : connection = connection ?? StdAsyncWorkerConnection();
 
   /// Perform a single [WorkRequest], and return a [WorkResponse].
+  @override
   Future<WorkResponse> performRequest(WorkRequest request);
 
   /// Run the worker loop. The returned [Future] doesn't complete until
   /// [connection#readRequest] returns `null`.
+  @override
   Future run() async {
     while (true) {
       WorkResponse response;

--- a/lib/src/worker/sync_worker_loop.dart
+++ b/lib/src/worker/sync_worker_loop.dart
@@ -15,12 +15,14 @@ abstract class SyncWorkerLoop implements WorkerLoop {
   final SyncWorkerConnection connection;
 
   SyncWorkerLoop({SyncWorkerConnection connection})
-      : this.connection = connection ?? StdSyncWorkerConnection();
+      : connection = connection ?? StdSyncWorkerConnection();
 
   /// Perform a single [WorkRequest], and return a [WorkResponse].
+  @override
   WorkResponse performRequest(WorkRequest request);
 
   /// Run the worker loop. Blocks until [connection#readRequest] returns `null`.
+  @override
   void run() {
     while (true) {
       WorkResponse response;

--- a/lib/src/worker/worker_connection.dart
+++ b/lib/src/worker/worker_connection.dart
@@ -43,6 +43,7 @@ abstract class AsyncWorkerConnection implements WorkerConnection {
 }
 
 abstract class SyncWorkerConnection implements WorkerConnection {
+  @override
   WorkRequest readRequest();
 }
 

--- a/lib/src/worker_protocol.pb.dart
+++ b/lib/src/worker_protocol.pb.dart
@@ -4,6 +4,7 @@
 //
 // @dart = 2.3
 // ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
+// ignore_for_file: annotate_overrides
 
 import 'dart:core' as $core;
 

--- a/lib/testing.dart
+++ b/lib/testing.dart
@@ -26,11 +26,13 @@ class TestStdinSync implements TestStdin {
   final Queue<int> pendingBytes = Queue<int>();
 
   /// Adds all the [bytes] to this stream.
+  @override
   void addInputBytes(List<int> bytes) {
     pendingBytes.addAll(bytes);
   }
 
   /// Add a -1 to signal EOF.
+  @override
   void close() {
     pendingBytes.add(-1);
   }
@@ -55,18 +57,20 @@ class TestStdinAsync implements TestStdin {
   StreamController<Uint8List> get controller => _controller;
 
   /// Adds all the [bytes] to this stream.
+  @override
   void addInputBytes(List<int> bytes) {
     _controller.add(Uint8List.fromList(bytes));
   }
 
   /// Closes this stream. This is necessary for the [AsyncWorkerLoop] to exit.
+  @override
   void close() {
     _controller.close();
   }
 
   @override
-  StreamSubscription<Uint8List> listen(onData(Uint8List bytes),
-      {Function onError, void onDone(), bool cancelOnError}) {
+  StreamSubscription<Uint8List> listen(void Function(Uint8List bytes) onData,
+      {Function onError, void Function() onDone, bool cancelOnError}) {
     return _controller.stream.listen(onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
@@ -108,6 +112,7 @@ abstract class TestWorkerLoop implements WorkerLoop {
 /// A [StdSyncWorkerConnection] which records its responses.
 class TestSyncWorkerConnection extends StdSyncWorkerConnection
     implements TestWorkerConnection {
+  @override
   final List<WorkResponse> responses = <WorkResponse>[];
 
   TestSyncWorkerConnection(Stdin stdinStream, Stdout stdoutStream)
@@ -141,6 +146,7 @@ class TestSyncWorkerLoop extends SyncWorkerLoop implements TestWorkerLoop {
   /// Adds [response] to the queue. These will be returned from
   /// [performResponse] in the order they are added, otherwise it will throw
   /// if the queue is empty.
+  @override
   void enqueueResponse(WorkResponse response) {
     _responses.addLast(response);
   }
@@ -149,6 +155,7 @@ class TestSyncWorkerLoop extends SyncWorkerLoop implements TestWorkerLoop {
 /// A [StdAsyncWorkerConnection] which records its responses.
 class TestAsyncWorkerConnection extends StdAsyncWorkerConnection
     implements TestWorkerConnection {
+  @override
   final List<WorkResponse> responses = <WorkResponse>[];
 
   TestAsyncWorkerConnection(
@@ -183,6 +190,7 @@ class TestAsyncWorkerLoop extends AsyncWorkerLoop implements TestWorkerLoop {
   /// Adds [response] to the queue. These will be returned from
   /// [performResponse] in the order they are added, otherwise it will throw
   /// if the queue is empty.
+  @override
   void enqueueResponse(WorkResponse response) {
     _responses.addLast(response);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,11 @@
 name: bazel_worker
-version: 0.1.23
+version: 0.1.24-dev
 
 description: Tools for creating a bazel persistent worker.
-author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/bazel_worker
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
   async: '>1.9.0 <3.0.0'

--- a/test/message_grouper_test.dart
+++ b/test/message_grouper_test.dart
@@ -24,8 +24,8 @@ void main() {
   });
 }
 
-void runTests(TestStdin stdinFactory(),
-    MessageGrouper messageGrouperFactory(Stdin stdinStream)) {
+void runTests(TestStdin Function() stdinFactory,
+    MessageGrouper Function(Stdin) messageGrouperFactory) {
   MessageGrouper messageGrouper;
 
   TestStdin stdinStream;
@@ -47,7 +47,7 @@ void runTests(TestStdin stdinFactory(),
   /// Make a simple message having the given [length]
   List<int> makeMessage(int length) {
     var result = <int>[];
-    for (int i = 0; i < length; i++) {
+    for (var i = 0; i < length; i++) {
       result.add(i & 0xff);
     }
     return result;
@@ -74,14 +74,14 @@ void runTests(TestStdin stdinFactory(),
     var len = 0x155;
     var msg = makeMessage(len);
     var encodedLen = [0xd5, 0x02];
-    await check([]..addAll(encodedLen)..addAll(msg), [msg]);
+    await check([...encodedLen, ...msg], [msg]);
   });
 
   test('Message with 3-byte length', () async {
     var len = 0x4103;
     var msg = makeMessage(len);
     var encodedLen = [0x83, 0x82, 0x01];
-    await check([]..addAll(encodedLen)..addAll(msg), [msg]);
+    await check([...encodedLen, ...msg], [msg]);
   });
 
   test('Multiple messages', () async {

--- a/test/worker_loop_test.dart
+++ b/test/worker_loop_test.dart
@@ -49,9 +49,9 @@ void main() {
 }
 
 void runTests<T extends TestWorkerConnection>(
-    TestStdin stdinFactory(),
-    T workerConnectionFactory(Stdin stdin, Stdout stdout),
-    TestWorkerLoop workerLoopFactory(T connection)) {
+    TestStdin Function() stdinFactory,
+    T Function(Stdin, Stdout) workerConnectionFactory,
+    TestWorkerLoop Function(T) workerLoopFactory) {
   TestStdin stdinStream;
   TestStdoutStream stdoutStream;
   T connection;

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -8,7 +8,7 @@
 set -e
 
 # Verify that the libraries are error free.
-dartanalyzer --fatal-warnings \
+dartanalyzer --fatal-infos --fatal-warnings \
   lib/bazel_worker.dart \
   lib/driver.dart \
   lib/testing.dart \
@@ -19,6 +19,6 @@ pub run test
 
 pushd e2e_test
 pub get
-dartanalyzer --fatal-warnings test/e2e_test.dart
+dartanalyzer --fatal-infos --fatal-warnings test/e2e_test.dart
 pub run test
 popd


### PR DESCRIPTION
- annotate_overrides
- omit_local_variable_types
- prefer_final_fields
- prefer_spread_collections
- unnecessary_this
- use_function_type_syntax_for_parameters

Fix travis to fail for lints with `--fatal-infos`.

Stop enforcing `sort_unnamed_constructor_first`.

Bump minimum SDK to 2.3.0 to allow spreads in collection literals.

Drop unused author field from pubspec.

Hand edit generated file to ignore annotate_overrides.