### PR TITLE
detect dead workers by a closed input stream instead of exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.23+1
+
+* Don't rely on `exitCode` to know when a worker terminates, instead wait for
+  the input stream to close.
+  * The SDK may also start throwing instead of returning a `null` here, so this
+    pre-emptively guards against that.
+
 ## 0.1.23
 
 * Support protobuf `1.x`.

--- a/lib/src/async_message_grouper.dart
+++ b/lib/src/async_message_grouper.dart
@@ -20,11 +20,12 @@ class AsyncMessageGrouper implements MessageGrouper {
   /// The input stream.
   final StreamQueue<List<int>> _inputQueue;
 
-  // Whether or not the input queue has already been cancelled.
-  bool _inputQueueCancelled = false;
-
   /// The current buffer.
   final Queue<int> _buffer = Queue<int>();
+
+  /// Completes after [cancel] is called or [inputStream] is closed.
+  Future<void> get done => _done.future;
+  final _done = Completer<void>();
 
   AsyncMessageGrouper(Stream<List<int>> inputStream)
       : _inputQueue = StreamQueue(inputStream);
@@ -43,7 +44,7 @@ class AsyncMessageGrouper implements MessageGrouper {
       }
 
       // If there is nothing left in the queue then cancel the subscription.
-      if (message == null) unawaited(_cancel());
+      if (message == null) unawaited(cancel());
 
       return message;
     } catch (e) {
@@ -54,14 +55,12 @@ class AsyncMessageGrouper implements MessageGrouper {
     }
   }
 
-  Future _cancel() {
-    if (!_inputQueueCancelled) {
-      _inputQueueCancelled = true;
+  /// Stop listening to the stream for further updates.
+  Future cancel() {
+    if (!_done.isCompleted) {
+      _done.complete(null);
       return _inputQueue.cancel();
     }
-    return Future.value(null);
+    return done;
   }
-
-  /// Stop listening to the stream for further updates.
-  Future cancel() => _cancel();
 }

--- a/lib/src/driver/driver_connection.dart
+++ b/lib/src/driver/driver_connection.dart
@@ -31,6 +31,8 @@ class StdDriverConnection implements DriverConnection {
   final AsyncMessageGrouper _messageGrouper;
   final StreamSink<List<int>> _outputStream;
 
+  Future<void> get done => _messageGrouper.done;
+
   StdDriverConnection(
       {Stream<List<int>> inputStream, StreamSink<List<int>> outputStream})
       : _messageGrouper = AsyncMessageGrouper(inputStream ?? stdin),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bazel_worker
-version: 0.1.24-dev
+version: 0.1.23+1
 
 description: Tools for creating a bazel persistent worker.
 homepage: https://github.com/dart-lang/bazel_worker


### PR DESCRIPTION
There has been a long standing issue where the exit code for detached processes was null - so we could never detect that they exited. This can cause builds to hang and continue to try scheduling work on a dead worker.

This fixes that by instead using the input stream (stdout of the worker) to detect a dead worker.