### PR TITLE
Avoid crashing on closed port in IsolateDriverConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.24
+
+* Check for closed port when trying to read a response in
+  `IsolateDriverConnection` and return `null` if there is nothing to be read.
+
 ## 0.1.23+1
 
 * Don't rely on `exitCode` to know when a worker terminates, instead wait for

--- a/lib/src/driver/driver_connection.dart
+++ b/lib/src/driver/driver_connection.dart
@@ -103,7 +103,9 @@ class IsolateDriverConnection implements DriverConnection {
 
   @override
   Future<WorkResponse> readResponse() async {
-    await _receivePortIterator.moveNext();
+    if (!await _receivePortIterator.moveNext()) {
+      return null;
+    }
     return WorkResponse.fromBuffer(_receivePortIterator.current as List<int>);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bazel_worker
-version: 0.1.23+1
+version: 0.1.24
 
 description: Tools for creating a bazel persistent worker.
 homepage: https://github.com/dart-lang/bazel_worker

--- a/test/driver_connection_test.dart
+++ b/test/driver_connection_test.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:isolate';
+import 'package:test/test.dart';
+
+import 'package:bazel_worker/src/driver/driver_connection.dart';
+
+void main() {
+  group('IsolateDriverConnection', () {
+    test('handles closed port', () async {
+      var isolatePort = ReceivePort();
+      var outsidePort = ReceivePort();
+      isolatePort.sendPort.send(outsidePort.sendPort);
+      var connection = await IsolateDriverConnection.create(isolatePort);
+
+      isolatePort.close();
+
+      expect(await connection.readResponse(), null);
+    });
+  });
+}

--- a/test/test_all.dart
+++ b/test/test_all.dart
@@ -5,9 +5,11 @@
 import 'driver_test.dart' as driver;
 import 'message_grouper_test.dart' as message_grouper;
 import 'worker_loop_test.dart' as worker_loop;
+import 'driver_connection_test.dart' as driver_connection;
 
 void main() {
   driver.main();
   message_grouper.main();
   worker_loop.main();
+  driver_connection.main();
 }


### PR DESCRIPTION
Previously we would crash with an exception in the proto code (trying to
call `length` on `null`). Instead we'll now return null if there is
nothing to be read.
