### PR TITLE
Implement isBroadcast for TestStdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.25
+
+* Add `isBroadcast` implementation to `TestStdin` classes.
+
 ## 0.1.24
 
 * Check for closed port when trying to read a response in

--- a/lib/testing.dart
+++ b/lib/testing.dart
@@ -43,6 +43,9 @@ class TestStdinSync implements TestStdin {
   }
 
   @override
+  bool get isBroadcast => false;
+
+  @override
   void noSuchMethod(Invocation invocation) {
     throw StateError('Unexpected invocation ${invocation.memberName}.');
   }
@@ -74,6 +77,9 @@ class TestStdinAsync implements TestStdin {
     return _controller.stream.listen(onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
+
+  @override
+  bool get isBroadcast => false;
 
   @override
   void noSuchMethod(Invocation invocation) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bazel_worker
-version: 0.1.24
+version: 0.1.25
 
 description: Tools for creating a bazel persistent worker.
 homepage: https://github.com/dart-lang/bazel_worker


### PR DESCRIPTION
In this package these streams are used with `StreamQueue` which now
calls `isBroadcast` to start listening eagerly. Implement that member so
that these classes stay compatible with `StreamQueue`.