### PR TITLE
Require protobuf 3.0.0 and prepare for 1.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.0-wip
 
-* Require `package:protobuf` ^3.0.0.
+* Require `package:protobuf` >= 3.0.0.
 * Require Dart SDK >= 2.19.0
 
 ## 1.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 1.0.3-dev
+## 1.1.0-wip
 
+* Require `package:protobuf` ^3.0.0.
 * Require Dart SDK >= 2.19.0
 
 ## 1.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0-wip
+## 1.0.3-wip
 
 * Require `package:protobuf` >= 3.0.0.
 * Require Dart SDK >= 2.19.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.3-wip
+## 1.0.3
 
 * Require `package:protobuf` >= 3.0.0.
 * Require Dart SDK >= 2.19.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bazel_worker
-version: 1.0.3-wip
+version: 1.0.3
 description: >-
   Protocol and utilities to implement or invoke persistent bazel workers.
 repository: https://github.com/dart-lang/bazel_worker

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bazel_worker
-version: 1.0.3-dev
+version: 1.1.0-wip
 description: >-
   Protocol and utilities to implement or invoke persistent bazel workers.
 repository: https://github.com/dart-lang/bazel_worker
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   async: ^2.5.0
-  protobuf: ^2.0.0
+  protobuf: ^3.0.0
 
 dev_dependencies:
   dart_flutter_team_lints: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bazel_worker
-version: 1.1.0-wip
+version: 1.0.3-wip
 description: >-
   Protocol and utilities to implement or invoke persistent bazel workers.
 repository: https://github.com/dart-lang/bazel_worker


### PR DESCRIPTION
Since `build_web_compilers` depends on this package, the previous constraint will limit many projects from (easily) moving to protobuf 3.0.0 and benefiting from its fixes.