### PR TITLE
Fix bug around handling of failures in `spawnWorker` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.1
+
+* Fix a bug where if spawnWorker threw an error, work requests would hang
+  forever instead of failing.
+
 ## 1.1.0
 
 * Add constructors with named parameters to

--- a/lib/src/driver/driver.dart
+++ b/lib/src/driver/driver.dart
@@ -120,10 +120,10 @@ class BazelWorkerDriver {
           _readyWorkers.remove(worker);
           _runWorkQueue();
         });
-      }).onError((e, s) {
+      }).onError<Object>((e, s) {
         _spawningWorkers.remove(futureWorker);
         if (attempt.responseCompleter.isCompleted) return;
-        attempt.responseCompleter.completeError(e ?? 'null', s);
+        attempt.responseCompleter.completeError(e, s);
       });
     }
     // Recursively calls itself until one of the bail out conditions are met.

--- a/lib/src/driver/driver.dart
+++ b/lib/src/driver/driver.dart
@@ -120,10 +120,10 @@ class BazelWorkerDriver {
           _readyWorkers.remove(worker);
           _runWorkQueue();
         });
-      }).catchError((Object e, StackTrace? s) {
+      }).onError((e, s) {
         _spawningWorkers.remove(futureWorker);
         if (attempt.responseCompleter.isCompleted) return;
-        attempt.responseCompleter.completeError(e, s);
+        attempt.responseCompleter.completeError(e ?? 'null', s);
       });
     }
     // Recursively calls itself until one of the bail out conditions are met.

--- a/lib/src/driver/driver.dart
+++ b/lib/src/driver/driver.dart
@@ -120,6 +120,10 @@ class BazelWorkerDriver {
           _readyWorkers.remove(worker);
           _runWorkQueue();
         });
+      }).catchError((e, s) {
+        _spawningWorkers.remove(futureWorker);
+        if (attempt.responseCompleter.isCompleted) return;
+        attempt.responseCompleter.completeError(e as Object, s as StackTrace?);
       });
     }
     // Recursively calls itself until one of the bail out conditions are met.

--- a/lib/src/driver/driver.dart
+++ b/lib/src/driver/driver.dart
@@ -120,10 +120,10 @@ class BazelWorkerDriver {
           _readyWorkers.remove(worker);
           _runWorkQueue();
         });
-      }).catchError((e, s) {
+      }).catchError((Object e, StackTrace? s) {
         _spawningWorkers.remove(futureWorker);
         if (attempt.responseCompleter.isCompleted) return;
-        attempt.responseCompleter.completeError(e as Object, s as StackTrace?);
+        attempt.responseCompleter.completeError(e, s);
       });
     }
     // Recursively calls itself until one of the bail out conditions are met.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: bazel_worker
-version: 1.1.0
+version: 1.1.1
 description: >-
   Protocol and utilities to implement or invoke persistent bazel workers.
 repository: https://github.com/dart-lang/bazel_worker

--- a/test/driver_test.dart
+++ b/test/driver_test.dart
@@ -139,6 +139,12 @@ void main() {
       });
     });
 
+    test('handles spawnWorker failures', () async {
+      driver = BazelWorkerDriver(() async => throw StateError('oh no!'),
+          maxRetries: 0);
+      expect(await driver!.doWork(WorkRequest()), completes);
+    });
+
     tearDown(() async {
       await driver?.terminateWorkers();
       expect(MockWorker.liveWorkers, isEmpty);

--- a/test/driver_test.dart
+++ b/test/driver_test.dart
@@ -140,8 +140,7 @@ void main() {
     });
 
     test('handles spawnWorker failures', () async {
-      driver = BazelWorkerDriver(
-          () => Future.error(StateError('oh no!'), StackTrace.current),
+      driver = BazelWorkerDriver(() async => throw StateError('oh no!'),
           maxRetries: 0);
       expect(driver!.doWork(WorkRequest()), throwsA(isA<StateError>()));
     });

--- a/test/driver_test.dart
+++ b/test/driver_test.dart
@@ -140,9 +140,10 @@ void main() {
     });
 
     test('handles spawnWorker failures', () async {
-      driver = BazelWorkerDriver(() async => throw StateError('oh no!'),
+      driver = BazelWorkerDriver(
+          () => Future.error(StateError('oh no!'), StackTrace.current),
           maxRetries: 0);
-      expect(await driver!.doWork(WorkRequest()), completes);
+      expect(driver!.doWork(WorkRequest()), throwsA(isA<StateError>()));
     });
 
     tearDown(() async {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/bazel_worker/issues/86

If a worker process fails to spawn, we will now complete the work attempt that caused the process to spawn with that failure, instead of never completing the attempt at all, causing a hang, and also leaking the async exception as an unhandled exception.

We could add retry logic in the future if we want, but it is probably unlikely that trying again will work. This way the actual failure should be reliably surfaced though.